### PR TITLE
feat(balancer): enhance resolver with caching and default TTL support

### DIFF
--- a/internal/transport/balancer/factory.go
+++ b/internal/transport/balancer/factory.go
@@ -36,5 +36,5 @@ func NewResolverWithBalancerType(balancerType BalancerType, config map[string]an
 	if err != nil {
 		return nil, err
 	}
-	return NewResolver(balancer), nil
+	return NewResolverWithDefaults(balancer), nil
 }


### PR DESCRIPTION
This pull request introduces DNS caching to the UDP target resolver, improving performance and reliability by reducing redundant DNS lookups. The resolver now supports configurable cache TTL and cache enablement, and logs cache hits and population for better observability. The changes also update constructors to default to using DNS caching.

### DNS Caching Support

* Added DNS cache to the `Resolver` struct, including cache TTL, enablement flag, and synchronization via a mutex. Introduced the `dnsCacheEntry` type and related fields.
* Implemented the `lookupIPs` method to handle DNS lookups with caching logic, cache population, and cache hit detection.
* Added utility functions `ipsToStrings` and `cloneIPs` for IP address handling and logging.

### Resolver Construction Changes

* Updated resolver constructors: `NewResolver` now accepts cache settings, and `NewResolverWithDefaults` enables DNS cache with a default TTL. Existing usages (including factory and default resolver) now use the new default constructor. [[1]](diffhunk://#diff-58a79e4a3a241d9d349a81fd56d9869b4f84a25b4c23e6f2d61341ac325e6101L39-R39) [[2]](diffhunk://#diff-0355ed4835ddc1c55179ab9b3e80ec392183883ea0ee7f38e4e24b42dd31ee51R20-R58) [[3]](diffhunk://#diff-0355ed4835ddc1c55179ab9b3e80ec392183883ea0ee7f38e4e24b42dd31ee51L95-R203)

### DNS Resolution and Logging Enhancements

* Modified `ResolveUDPTarget` to use the new caching-aware lookup method, and enhanced logging to include cache status and resolved IPs.

### Imports and Synchronization

* Added imports for `sync` and `time` to support DNS caching and synchronization.