### PR TITLE
feat: support tls-proxy for proxy-injector.

### DIFF
--- a/benchmark/scripts/manifest-arpc/kv-store-arpc-tcp-tls-proxy.yaml
+++ b/benchmark/scripts/manifest-arpc/kv-store-arpc-tcp-tls-proxy.yaml
@@ -1,0 +1,166 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  clusterIP: 10.96.88.88
+  ports:
+  - name: frontend
+    port: 80
+    targetPort: 8080
+  selector:
+    app: frontend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: frontend
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: appnetorg/kvstore-arpc-tcp:latest
+        name: frontend-kvstore-arpc-tcp
+        command:
+        - /app/frontend
+        args:
+        - -mtls
+        - -tls-ca-file=/app/certs/ca-cert.pem
+        - -tls-client-cert-file=/app/certs/client-cert.pem
+        - -tls-client-key-file=/app/certs/client-key.pem
+        - -server=kvstore.default.svc.cluster.local:11000
+        env:
+        - name: LOG_LEVEL
+          value: info
+        volumeMounts:
+        - name: tls-certs
+          mountPath: /app/certs
+          readOnly: true
+      - name: symphony-proxy
+        image: appnetorg/symphony-proxy-tcp:latest
+        command:
+        - /app/proxy
+        securityContext:
+          runAsUser: 1337
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+        args:
+        - -mtls
+        - -tls-cert-file=/app/certs/server-cert.pem
+        - -tls-key-file=/app/certs/server-key.pem
+        volumeMounts:
+        - name: tls-certs
+          mountPath: /app/certs
+          readOnly: true
+      volumes:
+      - name: tls-certs
+        secret:
+          secretName: kvstore-tls-certs
+      initContainers:
+      - name: set-iptables
+        image: appnetorg/symphony-proxy-tcp-init-container:latest
+        command:
+        - /bin/sh
+        - -c
+        - bash /apply_symphony_iptables.sh
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
+  selector:
+    matchLabels:
+      app: frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kvstore
+  labels:
+    app: kvstore
+spec:
+  clusterIP: None
+  ports:
+  - name: kvstore
+    port: 11000
+    protocol: TCP
+    targetPort: 11000
+  selector:
+    app: kvstore
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kvstore
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: kvstore
+      labels:
+        app: kvstore
+    spec:
+      containers:
+      - image: appnetorg/kvstore-arpc-tcp:latest
+        name: kvstore-kvstore-arpc-tcp
+        command:
+        - /app/kvstore
+        args:
+        - -mtls
+        - -tls-cert-file=/app/certs/server-cert.pem
+        - -tls-key-file=/app/certs/server-key.pem
+        - -tls-ca-file=/app/certs/ca-cert.pem
+        - -listen=:11000
+        env:
+        - name: LOG_LEVEL
+          value: info
+        volumeMounts:
+        - name: tls-certs
+          mountPath: /app/certs
+          readOnly: true
+      - name: symphony-proxy
+        image: appnetorg/symphony-proxy-tcp:latest
+        command:
+        - /app/proxy
+        securityContext:
+          runAsUser: 1337
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+        args:
+        - -mtls
+        - -tls-cert-file=/app/certs/server-cert.pem
+        - -tls-key-file=/app/certs/server-key.pem
+        volumeMounts:
+        - name: tls-certs
+          mountPath: /app/certs
+          readOnly: true
+      volumes:
+      - name: tls-certs
+        secret:
+          secretName: kvstore-tls-certs
+      initContainers:
+      - name: set-iptables
+        image: appnetorg/symphony-proxy-tcp-init-container:latest
+        command:
+        - /bin/sh
+        - -c
+        - bash /apply_symphony_iptables.sh
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+            - NET_ADMIN
+  selector:
+    matchLabels:
+      app: kvstore

--- a/cmd/proxy-injector/README.md
+++ b/cmd/proxy-injector/README.md
@@ -14,7 +14,11 @@ pip install pyyaml
 
 - `-f, --file`: Input YAML file. Reads from stdin if not specified.
 - `-o, --output`: Output YAML file. Writes to stdout if not specified.
-- `-m, --mode`: Proxy mode: `symphony` or `h2` (default: `symphony`).
+- `-m, --mode`: Proxy mode: `symphony`, `h2`, or `tcp` (default: `symphony`).
+- `--tls`: Enable mTLS for the proxy.
+- `--tls-cert-path`: Path to TLS certificate file in container (default: `/app/certs/server-cert.pem`).
+- `--tls-key-path`: Path to TLS key file in container (default: `/app/certs/server-key.pem`).
+- `--tls-secret-name`: Name of the Kubernetes secret containing TLS certificates (default: `kvstore-tls-certs`).
 
 ### Inject via file
 
@@ -41,6 +45,23 @@ cat input.yaml | python symphony-injector.py > output.yaml
 ```bash
 # Use h2 mode
 python symphony-injector.py -f input.yaml -m h2 -o output.yaml
+
+# Use tcp mode
+python symphony-injector.py -f input.yaml -m tcp -o output.yaml
+```
+
+### Enable TLS for proxy
+
+```bash
+# Inject proxy with mTLS enabled
+python symphony-injector.py -f input.yaml -m tcp --tls -o output.yaml
+
+# Customize TLS certificate paths and secret name
+python symphony-injector.py -f input.yaml -m tcp --tls \
+  --tls-cert-path=/custom/path/cert.pem \
+  --tls-key-path=/custom/path/key.pem \
+  --tls-secret-name=my-tls-secret \
+  -o output.yaml
 ```
 
 ## Opt-out


### PR DESCRIPTION
This pull request adds support for mTLS (mutual TLS) injection to the proxy-injector tool, allowing users to enable TLS for the Symphony proxy in Kubernetes manifests. It introduces new CLI options for configuring TLS certificate paths and secret names, updates the injection logic to handle TLS configuration, and provides improved documentation and usage examples for the new features.

**Proxy-injector TLS/mTLS support:**

* Added new CLI flags to `symphony-injector.py` for enabling mTLS (`--tls`), specifying certificate/key paths (`--tls-cert-path`, `--tls-key-path`), and secret name (`--tls-secret-name`). These options allow users to easily configure TLS for the injected proxy.
* Updated the proxy injection logic to add TLS arguments, volume mounts, and secret volumes to the injected proxy container when TLS is enabled. This ensures the proxy is properly configured for secure communication.
* Modified the YAML processing and main entrypoint to pass TLS options throughout the injection workflow, enabling seamless mTLS support for all injected deployments. [[1]](diffhunk://#diff-9ca73e2166483a298c747e980dd219ee12f7e69b15b8dea64f4021136dd99523L61-R94) [[2]](diffhunk://#diff-9ca73e2166483a298c747e980dd219ee12f7e69b15b8dea64f4021136dd99523L74-R107)

**Documentation and usage improvements:**

* Updated the `README.md` for proxy-injector to document the new TLS options and provide example commands for injecting proxies with mTLS enabled, including customization of certificate paths and secret names. [[1]](diffhunk://#diff-1cd6aa67711be12794f9d93a0160281e8ac05307b9b0f187ba7b49fc6193622cL17-R21) [[2]](diffhunk://#diff-1cd6aa67711be12794f9d93a0160281e8ac05307b9b0f187ba7b49fc6193622cR48-R64)

**Example manifest for mTLS-enabled deployment:**

* Added a new example Kubernetes manifest (`kv-store-arpc-tcp-tls-proxy.yaml`) demonstrating a frontend and kvstore deployment with Symphony proxy injected and mTLS configured using secrets and volume mounts.