### PR TITLE
fix: reuse connection for kvstore-grpc.

### DIFF
--- a/benchmark/scripts/benchmark/run_motivation.py
+++ b/benchmark/scripts/benchmark/run_motivation.py
@@ -36,7 +36,7 @@ manifest_dict = {
     "kv-store-grpc-istio-h2": os.path.join(ARPC_DIR, "benchmark/kv-store-grpc/manifest/kvstore-istio-h2.yaml"),
     "kv-store-grpc-istio-tcp": os.path.join(ARPC_DIR, "benchmark/kv-store-grpc/manifest/kvstore-istio-tcp.yaml"),
     "kv-store-grpc-proxy-h2": os.path.join(ARPC_DIR, "benchmark/kv-store-grpc/manifest/kvstore-proxy-h2.yaml"),
-    "kv-store-grpc-proxy-tcp": os.path.join(ARPC_DIR, "benchmark/kv-store-grpc/manifest/kvstore-proxy-h2.yaml"),
+    "kv-store-grpc-proxy-tcp": os.path.join(ARPC_DIR, "benchmark/kv-store-grpc/manifest/kvstore-proxy-tcp.yaml"),
     "kv-store-arpc-tcp-direct": os.path.join(ARPC_DIR, "benchmark/scripts/manifest-arpc/kv-store-arpc-tcp.yaml"),
     "kv-store-arpc-tcp-tls": os.path.join(ARPC_DIR, "benchmark/scripts/manifest-arpc/kv-store-arpc-tcp-tls.yaml"),
     "kv-store-arpc-tcp-tls-proxy-no-tls": os.path.join(ARPC_DIR, "benchmark/scripts/manifest-arpc/kv-store-arpc-tcp-tls-proxy-no-tls.yaml"),
@@ -143,7 +143,7 @@ def run_wrk_and_collect_latency(application_name):
     logger.info(f"Running wrk for {application_name}")
     
     # Run wrk for latency test
-    cmd = [wrk_path, "-d", "60s", "-t", "1", "-c", "1", "http://10.96.88.88:80", "-s", lua_path, "-L"]
+    cmd = [wrk_path, "-d", "600s", "-t", "1", "-c", "1", "http://10.96.88.88:80", "-s", lua_path, "-L"]
     print(" ".join(cmd))
     result = subprocess.run(
         " ".join(cmd),


### PR DESCRIPTION
This pull request refactors the gRPC client connection logic in the `frontend.go` file to establish the connection once at startup rather than on every request, improving efficiency and resource management. Additionally, it corrects a manifest path in the benchmarking script and increases the duration of latency tests for more robust benchmarking.

### Backend connection management improvements
* Refactored the gRPC client connection in `frontend.go` to be initialized once in `main()` and reused for all HTTP requests, instead of creating and closing the connection on every request. This change reduces connection overhead and improves performance. (`benchmark/kv-store-grpc/frontend/frontend.go`) [[1]](diffhunk://#diff-2778b3a0845eb3208e142d89cb0a8d919fd7b54acc744819f7d14db71f723f1bR24-R25) [[2]](diffhunk://#diff-2778b3a0845eb3208e142d89cb0a8d919fd7b54acc744819f7d14db71f723f1bL74-L85) [[3]](diffhunk://#diff-2778b3a0845eb3208e142d89cb0a8d919fd7b54acc744819f7d14db71f723f1bR113-R123)

### Benchmarking script fixes and improvements
* Fixed the manifest path for the `kv-store-grpc-proxy-tcp` configuration to use the correct YAML file in `run_motivation.py`. (`benchmark/scripts/benchmark/run_motivation.py`)
* Increased the latency test duration from 60 seconds to 600 seconds in the benchmarking script to allow for more comprehensive performance measurements. (`benchmark/scripts/benchmark/run_motivation.py`)