### PR TITLE
feat: stop wrk when the lua script finished.

### DIFF
--- a/benchmark/meta-kv-trace/kvstore-wrk.lua
+++ b/benchmark/meta-kv-trace/kvstore-wrk.lua
@@ -25,6 +25,11 @@ end
 -- Return one request per wrk iteration
 function request()
   if i > #lines then
+    -- SIGNAL: Print a unique string that Python can detect
+    io.stdout:write("__DONE__\n")
+    io.stdout:flush()
+    
+    -- Stop the current thread (failsafe)
     wrk.thread:stop()
     return nil
   end


### PR DESCRIPTION
This pull request introduces a more robust mechanism for running and terminating the `wrk` benchmarking tool in the motivational benchmark suite. The main change is to synchronize the Lua script and Python controller: the Lua script now emits a unique signal when it finishes, and the Python script listens for this signal to gracefully stop `wrk` and collect results in real time. This improves reliability, prevents premature termination, and ensures all latency metrics are captured even if `wrk` exits with a non-zero code.

**Benchmark process control improvements:**

* The Lua script (`kvstore-wrk.lua`) now prints a unique string (`__DONE__`) when it completes all requests, which Python can detect to trigger a clean shutdown of `wrk`.
* The Python script (`run_motivation.py`) now starts `wrk` as a subprocess with real-time output monitoring, waits for the `__DONE__` signal, and sends a `SIGINT` to terminate `wrk` gracefully.
* Added the `signal` module import to support sending signals to subprocesses.

**Output handling and metric extraction:**

* The Python script now reads `wrk` output line-by-line, reconstructs the full output, and logs both stdout and stderr for better debugging and analysis.
* Improved error handling: the script accepts non-zero exit codes from `wrk` if valid latency statistics are present, ensuring metrics are not missed due to process termination.