### PR TITLE
feat: add error packet handling.

### DIFF
--- a/cmd/proxy-buffer/buffer.go
+++ b/cmd/proxy-buffer/buffer.go
@@ -281,6 +281,41 @@ func (pb *PacketBuffer) deserializePacket(data []byte) (*packet.DataPacket, erro
 	return dataPacket, nil
 }
 
+// ProcessErrorPacket processes an error packet and returns a BufferedPacket for forwarding.
+// Error packets are not buffered or fragmented - they fit in one MTU and are forwarded directly.
+func (pb *PacketBuffer) ProcessErrorPacket(data []byte, src *net.UDPAddr) (*util.BufferedPacket, error) {
+	// Deserialize error packet
+	codec := &packet.ErrorPacketCodec{}
+	packetAny, err := codec.Deserialize(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize error packet: %w", err)
+	}
+
+	errorPacket, ok := packetAny.(*packet.ErrorPacket)
+	if !ok {
+		return nil, fmt.Errorf("unexpected packet type in ProcessErrorPacket")
+	}
+
+	// Create destination address from the packet's routing info
+	peer := &net.UDPAddr{IP: net.IP(errorPacket.DstIP[:]), Port: int(errorPacket.DstPort)}
+
+	// Create BufferedPacket with error message as payload
+	bufferedPacket := &util.BufferedPacket{
+		Payload:      []byte(errorPacket.ErrorMsg),
+		Source:       src,
+		Peer:         peer,
+		PacketType:   util.PacketTypeError,
+		RPCID:        errorPacket.RPCID,
+		DstIP:        errorPacket.DstIP,
+		DstPort:      errorPacket.DstPort,
+		SrcIP:        errorPacket.SrcIP,
+		SrcPort:      errorPacket.SrcPort,
+		TotalPackets: 1,
+	}
+
+	return bufferedPacket, nil
+}
+
 // cleanupRoutine periodically cleans up expired fragments
 func (pb *PacketBuffer) cleanupRoutine() {
 	for {

--- a/cmd/proxy-buffer/main.go
+++ b/cmd/proxy-buffer/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/appnet-org/arpc/cmd/proxy-buffer/util"
 	"github.com/appnet-org/arpc/pkg/logging"
+	"github.com/appnet-org/arpc/pkg/packet"
 	"github.com/appnet-org/arpc/pkg/transport"
 	"go.uber.org/zap"
 )
@@ -205,6 +206,48 @@ func runProxyServer(port int, state *ProxyState, config *Config) error {
 func handlePacket(conn *net.UDPConn, state *ProxyState, src *net.UDPAddr, data []byte, config *Config) {
 	ctx := context.Background()
 
+	// Check if this is an error packet (PacketTypeID == 3)
+	if len(data) > 0 && data[0] == byte(packet.PacketTypeError.TypeID) {
+		// Process error packet - forward directly without element chain
+		bufferedPacket, err := state.packetBuffer.ProcessErrorPacket(data, src)
+		if err != nil {
+			logging.Error("Error processing error packet", zap.Error(err))
+			return
+		}
+
+		// Serialize the error packet for forwarding
+		errorPacket := &packet.ErrorPacket{
+			PacketTypeID: packet.PacketTypeError.TypeID,
+			RPCID:        bufferedPacket.RPCID,
+			DstIP:        bufferedPacket.DstIP,
+			DstPort:      bufferedPacket.DstPort,
+			SrcIP:        bufferedPacket.SrcIP,
+			SrcPort:      bufferedPacket.SrcPort,
+			ErrorMsg:     string(bufferedPacket.Payload),
+		}
+
+		codec := &packet.ErrorPacketCodec{}
+		serialized, err := codec.Serialize(errorPacket, nil)
+		if err != nil {
+			logging.Error("Failed to serialize error packet for forwarding", zap.Error(err))
+			return
+		}
+
+		// Forward the error packet to the destination
+		if _, err := conn.WriteToUDP(serialized, bufferedPacket.Peer); err != nil {
+			logging.Error("Failed to forward error packet", zap.Error(err))
+			return
+		}
+
+		logging.Debug("Forwarded error packet",
+			zap.Uint64("rpcID", bufferedPacket.RPCID),
+			zap.String("from", bufferedPacket.Source.String()),
+			zap.String("to", bufferedPacket.Peer.String()),
+			zap.String("errorMsg", string(bufferedPacket.Payload)))
+
+		return
+	}
+
 	// Process packet - returns nil if still buffering fragments
 	// Returns a complete BufferedPacket only when ALL fragments have been received
 	bufferedPacket, err := state.packetBuffer.ProcessPacket(data, src)
@@ -252,7 +295,7 @@ func handlePacket(conn *net.UDPConn, state *ProxyState, src *net.UDPAddr, data [
 		logging.Error("Error processing packet through element chain or packet was dropped",
 			zap.Error(err))
 		// Send error packet back to the source
-		if sendErr := util.SendErrorPacket(conn, bufferedPacket.Source, bufferedPacket.RPCID, err.Error()); sendErr != nil {
+		if sendErr := util.SendErrorPacket(conn, bufferedPacket.Source, bufferedPacket.RPCID, err.Error(), bufferedPacket.SrcIP, bufferedPacket.SrcPort, bufferedPacket.DstIP, bufferedPacket.DstPort); sendErr != nil {
 			logging.Error("Failed to send error packet", zap.Error(sendErr))
 		}
 		return

--- a/cmd/proxy-buffer/util/send_packet.go
+++ b/cmd/proxy-buffer/util/send_packet.go
@@ -9,12 +9,16 @@ import (
 	"go.uber.org/zap"
 )
 
-// sendErrorPacket sends an error packet back to the source
-func SendErrorPacket(conn *net.UDPConn, dest *net.UDPAddr, rpcID uint64, errorMsg string) error {
+// SendErrorPacket sends an error packet back to the source with routing information
+func SendErrorPacket(conn *net.UDPConn, dest *net.UDPAddr, rpcID uint64, errorMsg string, dstIP [4]byte, dstPort uint16, srcIP [4]byte, srcPort uint16) error {
 	// Create error packet
 	errorPacket := &packet.ErrorPacket{
 		PacketTypeID: packet.PacketTypeError.TypeID,
 		RPCID:        rpcID,
+		DstIP:        dstIP,
+		DstPort:      dstPort,
+		SrcIP:        srcIP,
+		SrcPort:      srcPort,
 		ErrorMsg:     errorMsg,
 	}
 
@@ -37,4 +41,3 @@ func SendErrorPacket(conn *net.UDPConn, dest *net.UDPAddr, rpcID uint64, errorMs
 
 	return nil
 }
-

--- a/cmd/proxy/util/send_packet.go
+++ b/cmd/proxy/util/send_packet.go
@@ -9,12 +9,16 @@ import (
 	"go.uber.org/zap"
 )
 
-// sendErrorPacket sends an error packet back to the source
-func SendErrorPacket(conn *net.UDPConn, dest *net.UDPAddr, rpcID uint64, errorMsg string) error {
+// SendErrorPacket sends an error packet back to the source with routing information
+func SendErrorPacket(conn *net.UDPConn, dest *net.UDPAddr, rpcID uint64, errorMsg string, dstIP [4]byte, dstPort uint16, srcIP [4]byte, srcPort uint16) error {
 	// Create error packet
 	errorPacket := &packet.ErrorPacket{
 		PacketTypeID: packet.PacketTypeError.TypeID,
 		RPCID:        rpcID,
+		DstIP:        dstIP,
+		DstPort:      dstPort,
+		SrcIP:        srcIP,
+		SrcPort:      srcPort,
 		ErrorMsg:     errorMsg,
 	}
 


### PR DESCRIPTION
This pull request enhances error packet handling in both the proxy and proxy-buffer components, ensuring error packets are correctly detected, processed, forwarded, and tested. The changes introduce a dedicated method for error packet processing, improve routing information propagation, and add comprehensive tests for error packet serialization, deserialization, and validation.

**Error Packet Handling Improvements:**

* Added a `ProcessErrorPacket` method to `PacketBuffer` in both `cmd/proxy/buffer.go` and `cmd/proxy-buffer/buffer.go`, enabling direct processing and forwarding of error packets without fragmentation. This method constructs a `BufferedPacket` with full routing information. [[1]](diffhunk://#diff-3c6139cda7978651d37a3207669ef7db75db6aef3a09152d388e7009c464f6cdR432-R468) [[2]](diffhunk://#diff-fd090fea7a1e370c56e4e23369f723a241e09cb2d019ef7f858d04dc02f5cb08R284-R318)
* Updated the `handlePacket` logic in both `cmd/proxy/main.go` and `cmd/proxy-buffer/main.go` to detect error packets by their type ID, process them using the new method, and forward them directly to the intended peer, bypassing the element chain. [[1]](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aR212-R253) [[2]](diffhunk://#diff-e0d1db06640b6aeb15b8bb6519e989260a0b26d4aad77e251f29cac4400b86c0R209-R250)

**Error Packet Routing and Serialization:**

* Modified `SendErrorPacket` in `cmd/proxy/util/send_packet.go` and `cmd/proxy-buffer/util/send_packet.go` to include source and destination IP/port fields in error packets, ensuring accurate routing information is preserved and transmitted.
* Updated all usages of `SendErrorPacket` to pass the new routing parameters. [[1]](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aL277-R320) [[2]](diffhunk://#diff-e0d1db06640b6aeb15b8bb6519e989260a0b26d4aad77e251f29cac4400b86c0L255-R298)

**Testing Enhancements:**

* Added extensive tests for error packet serialization/deserialization, MTU validation, and the new error packet handling logic in both `cmd/proxy/main_test.go` and `cmd/proxy/buffer_test.go`. These tests verify correct field propagation, error detection, and boundary conditions. [[1]](diffhunk://#diff-00a29217568d03eb4414f2a854559d45900ab35dba9a335ed95d0637149919f9R642-R783) [[2]](diffhunk://#diff-9d6cd311932093e133c9af754033d2531d29057ade8f550657bb0d350e91c977R1371-R1561)

**Other Changes:**

* Set the default log level to "debug" in `cmd/proxy/main.go` to aid in development and troubleshooting.
* Added missing imports for the `packet` package where required. [[1]](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aR15) [[2]](diffhunk://#diff-e0d1db06640b6aeb15b8bb6519e989260a0b26d4aad77e251f29cac4400b86c0R15)

These changes collectively improve the reliability and observability of error handling in the proxy system, ensuring error packets are robustly managed and tested.